### PR TITLE
Remove suffix, prefix from plugin filename

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,9 @@ FUNCTION(add_xplane_plugin library_name library_version ...)
     ENDIF()
     add_xplane_sdk_definitions(${library_name} ${library_version})
 
+    SET_TARGET_PROPERTIES(${library_name} PROPERTIES PREFIX "")
+    SET_TARGET_PROPERTIES(${library_name} PROPERTIES SUFFIX "")
+
     #link flags
     IF(APPLE)
         SET_PROPERTY(TARGET ${library_name} APPEND_STRING PROPERTY LINK_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fPIC -fvisibility=hidden -bundle")


### PR DESCRIPTION
Otherwise the plugin is named lin.xpl.so, win.xpl.dll, etc.

Fixes #1